### PR TITLE
shellcheck

### DIFF
--- a/install
+++ b/install
@@ -5,7 +5,7 @@ set -eu
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ## Bring in some helper functions
-source $here/util
+source "$here/util"
 
 ## Sanity-check
 log_start "Checking environment... "
@@ -59,7 +59,7 @@ while getopts ":g:r:t:Gdw:h" opt; do
       working_directory=$OPTARG
       ;;
     h)
-      show_help $0
+      show_help "$0"
       ;;
     \?)
       log "ERROR invalid option: -$OPTARG" >&2
@@ -77,8 +77,8 @@ if [ "$(id -u)" != "0" ]; then
   exit 1
 fi
 
-space=$(df -B 1G $working_directory | tail -n1 | sed 's/ \+/ /g' | cut -d' ' -f4)
-if [ $space -lt $required_space ];
+space=$(df -B 1G "$working_directory" | tail -n1 | sed 's/ \+/ /g' | cut -d' ' -f4)
+if [ "$space" -lt "$required_space" ];
 then
   log "WARNING: It *looks* like you don't have enough space for the install"
   log "You need ~${minimal_space}GB for the minimal ISO and ~${graphical_space}GB for the graphical ISO"
@@ -108,7 +108,7 @@ then
   exit 1
 fi
 
-pushd $working_directory
+pushd "$working_directory"
   log "Downloading NixOS $iso"
   mkdir -p mnt host/nix
 
@@ -126,7 +126,7 @@ pushd $working_directory
 
   ## Setup the chroot environment before install
   log "Embarking stage1!"
-  $here/stage1 $here $root_mount $root_type $grub_device $digitalocean
+  "$here/stage1" "$here" "$root_mount" "$root_type" "$grub_device" "$digitalocean"
 
   ## Minimize residual space usage
   rm -rf ./host

--- a/setup-network
+++ b/setup-network
@@ -5,17 +5,17 @@ set -u
 ## Inspect what we can
 echo "Inspecting eth0 and eth1..."
 interfaces=/etc/network/interfaces
-gateway=$(grep gateway $interfaces | awk '{print $2}')
-ns1=$(grep "dns-nameservers" $interfaces | awk '{print $2}')
-ns2=$(grep "dns-nameservers" $interfaces | awk '{print $3}')
+gateway=$(grep gateway "$interfaces" | awk '{print $2}')
+ns1=$(grep "dns-nameservers" "$interfaces" | awk '{print $2}')
+ns2=$(grep "dns-nameservers" "$interfaces" | awk '{print $3}')
 
-eth0_enabled=$(grep eth0 $interfaces)
-eth0_address=$(grep address $interfaces | awk '{print $2}' | head -1)
-eth0_prefix_length=$(grep -Eo "/..?" $interfaces | sed 's_/__' | head -1)
+eth0_enabled=$(grep eth0 "$interfaces")
+eth0_address=$(grep address "$interfaces" | awk '{print $2}' | head -1)
+eth0_prefix_length=$(grep -Eo "/..?" "$interfaces" | sed 's_/__' | head -1)
 
-eth1_enabled=$(grep eth1 $interfaces)
-eth1_address=$(grep address $interfaces | awk '{print $2}' | tail -1)
-eth1_prefix_length=$(grep -Eo "/..?" $interfaces | sed 's_/__' | tail -1)
+eth1_enabled=$(grep eth1 "$interfaces")
+eth1_address=$(grep address "$interfaces" | awk '{print $2}' | tail -1)
+eth1_prefix_length=$(grep -Eo "/..?" "$interfaces" | sed 's_/__' | tail -1)
 
 ## Takes 1) interface name; 2) address; 3) prefix length
 function enable_interface
@@ -36,14 +36,14 @@ EOF
   ip route add default via "$3" || true
 }
 
-[ -n "$eth0_enabled" ] && enable_interface eth0 $eth0_address $eth0_prefix_length
-[ -n "$eth1_enabled" ] && enable_interface eth1 $eth1_address $eth1_prefix_length
+[ -n "$eth0_enabled" ] && enable_interface eth0 "$eth0_address" "$eth0_prefix_length"
+[ -n "$eth1_enabled" ] && enable_interface eth1 "$eth1_address" "$eth1_prefix_length"
 
 # NixOS 16.03 uses newer naming
-[ -n "$eth0_enabled" ] && enable_interface enp0s3 $eth0_address $eth0_prefix_length
-[ -n "$eth1_enabled" ] && enable_interface enp0s4 $eth1_address $eth1_prefix_length
+[ -n "$eth0_enabled" ] && enable_interface enp0s3 "$eth0_address" "$eth0_prefix_length"
+[ -n "$eth1_enabled" ] && enable_interface enp0s4 "$eth1_address" "$eth1_prefix_length"
 
-enable_dns $ns1 $ns2 $gateway
+enable_dns "$ns1" "$ns2" "$gateway"
 
 echo "All set!"
 

--- a/stage1
+++ b/stage1
@@ -9,14 +9,14 @@ grub_device=$4
 digitalocean=$5
 
 ## Bring in some helper functions
-. $here/util
+. "$here/util"
 
 ## Enable networking
 log "Setting up chroot networking"
 cd host
 mkdir -p etc dev proc sys
 cp /etc/resolv.conf etc/external-resolv.conf
-for fn in dev proc sys; do mount --bind /$fn $fn; done
+for fn in dev proc sys; do mount --bind "/$fn" "$fn"; done
 
 ## Patch the ISO for local chroot
 log_start "Looking for NixOS init... "
@@ -28,11 +28,11 @@ log_end "$BASH"
 
 ## Don't run systemd on chroot start, run our stage2 script
 log "Patching init"
-sed -i "s,exec systemd,exec /$BASH -i /nixos-in-place/stage2 $root_mount $root_type $grub_device $digitalocean," $INIT
-sed -i "s,starting systemd,starting /nixos-in-place/stage2," $INIT
+sed -i "s,exec systemd,exec /$BASH -i /nixos-in-place/stage2 $root_mount $root_type $grub_device $digitalocean," "$INIT"
+sed -i "s,starting systemd,starting /nixos-in-place/stage2," "$INIT"
 
 ## Don't try to remount / since we didn't do a proper phase 1
-sed -i "s|mount -n -o remount,rw none /|echo 'not remounting /'|" $INIT
+sed -i "s|mount -n -o remount,rw none /|echo 'not remounting /'|" "$INIT"
 
 ## The chroot will install outside of itself, into the main system
 log "Binding remaining environment"
@@ -41,11 +41,11 @@ mount --bind /nixos nixos
 
 ## Allow stage2 to access these scripts
 mkdir -p nixos-in-place
-mount --bind $here nixos-in-place
+mount --bind "$here" nixos-in-place
 
 ## Imbue the modified live CD environment so we can install
 log "Embarking stage2!"
-chroot . /$INIT
+chroot . "/$INIT"
 
 ## Various platforms use different flags; just try what we can to clean up
 log "Cleaning up mounts"

--- a/stage2
+++ b/stage2
@@ -8,7 +8,7 @@ grub_device=$3
 digitalocean=$4
 digitalocean_configs=""
 
-if [ "$digitalocean" == "true" ];
+if [ "$digitalocean" = "true" ];
 then
   digitalocean_configs="
     ## Digital Ocean networking setup; manage interfaces manually
@@ -33,7 +33,7 @@ then
 fi
 
 ## Enable host resolution
-cp /etc/{external-,}resolv.conf
+cp /etc/external-resolv.conf /etc/resolv.conf
 
 ## Install dependencies; it's easier to do this here, in the Nix chroot,
 ## since we don't rely on the host system.
@@ -71,11 +71,11 @@ EOF
 
 ## Add in our configuration additions
 nixos_dir=/nixos/etc/nixos
-cp $nixos_dir/{,backup-}configuration.nix
+cp $nixos_dir/configuration.nix $nixos_dir/backup-configuration.nix
 sed -i 's|\(\s*\)\(./hardware-configuration.nix\)|\1\2\n\1./nixos-in-place.nix|' $nixos_dir/configuration.nix
 
 ## Remove the automatically-generated fileSystems configuration
-mv $nixos_dir/{,backup-}hardware-configuration.nix
+mv $nixos_dir/hardware-configuration.nix $nixos_dir/backup-hardware-configuration.nix
 pcregrep -Mv "fileSystems.\"/\"[\s\S]*};" $nixos_dir/backup-hardware-configuration.nix > $nixos_dir/hardware-configuration.nix
 
 ## Installs grub and a base NixOS system; after a reboot, we're golden

--- a/util
+++ b/util
@@ -5,7 +5,7 @@ set -eu
 check_existence()
 {
   set +e
-  which $1 > /dev/null 2>&1
+  which "$1" > /dev/null 2>&1
   exists=$?
   if [ ! "$exists" -eq "0" ];
   then
@@ -30,8 +30,8 @@ show_help()
 }
 
 log()
-{ printf ">>> $@\n"; }
+{ printf ">>> %s\n" "$*"; }
 log_start()
-{ printf ">>> $@"; }
+{ printf ">>> %s" "$*"; }
 log_end()
-{ printf "$@\n"; }
+{ printf "%s\n" "$*"; }


### PR DESCRIPTION
Apply various changes suggested by the ShellCheck util
<http://www.shellcheck.net/>; mainly quoting variable expansions and
removing Bashisms in scripts where the shebang says /bin/sh.

This may help running nixos-in-place from a directory with spaces in its
name.