### PR TITLE
Automatically enable sshd

### DIFF
--- a/install
+++ b/install
@@ -132,6 +132,9 @@ pushd "$working_directory"
   rm -rf ./host
 popd
 
+## Install root authorized keys
+cp -r /root/.ssh /nixos/root/
+
 ## Installation is complete
 log_start "Reboot into NixOS now? [yn] "
 read -n 1 -r

--- a/stage2
+++ b/stage2
@@ -73,6 +73,7 @@ EOF
 nixos_dir=/nixos/etc/nixos
 cp $nixos_dir/configuration.nix $nixos_dir/backup-configuration.nix
 sed -i 's|\(\s*\)\(./hardware-configuration.nix\)|\1\2\n\1./nixos-in-place.nix|' $nixos_dir/configuration.nix
+sed -i 's/# services\.openssh/services\.openssh/' $nixos_dir/configuration.nix
 
 ## Remove the automatically-generated fileSystems configuration
 mv $nixos_dir/hardware-configuration.nix $nixos_dir/backup-hardware-configuration.nix


### PR DESCRIPTION
What was your initial motivation to not automatically enable openssh? Since it's so simple I'm sure you would have if you thought it was a good idea.

Basically these two changes make it so that whoever is root on the machine now is able to login to the machine when it's booted into nixos, no console needed.

I think this properly deals with a security risk because the default setting for root login is set to "without-password" leaving you with only key authentication.