### PR TITLE
use array for fileSystem options

### DIFF
--- a/stage2
+++ b/stage2
@@ -58,7 +58,7 @@ cat <<EOF > /nixos/etc/nixos/nixos-in-place.nix
     "/" = {
       device = "/old-root/nixos";
       fsType = "none";
-      "options" = "bind";
+      options = [ "bind" ];
     };
     "/old-root" = {
       device = "$root_mount";


### PR DESCRIPTION
This avoids future deprecation of options string support. See https://github.com/NixOS/nixpkgs/blob/release-16.03/nixos/modules/tasks/filesystems.nix#L51