### PR TITLE
symlink the original authorized_keys to /root/.ssh

### DIFF
--- a/stage2
+++ b/stage2
@@ -30,6 +30,9 @@ then
   ## update each boot.
   mkdir -p /nixos/etc/network
   ln -sf /old-root/etc/network/interfaces /nixos/etc/network/
+  
+  ## Use the original authorized_keys that DO added
+  ln -sf /old-root/root/.ssh/authorized_keys /root/.ssh/authorized_keys
 fi
 
 ## Enable host resolution


### PR DESCRIPTION
This will symlink authorized_keys from /old-root to the one from NixOS, but only on a DO system. This was also discussed in #5.