### PR TITLE
use NIXOS_INSTALL_REEXEC=1 for nixos-install

### DIFF
--- a/stage2
+++ b/stage2
@@ -85,5 +85,5 @@ mv $nixos_dir/hardware-configuration.nix $nixos_dir/backup-hardware-configuratio
 pcregrep -Mv "fileSystems.\"/\"[\s\S]*};" $nixos_dir/backup-hardware-configuration.nix > $nixos_dir/hardware-configuration.nix
 
 ## Installs grub and a base NixOS system; after a reboot, we're golden
-nixos-install --root /nixos
+NIXOS_INSTALL_REEXEC=1 nixos-install --root /nixos
 exit


### PR DESCRIPTION
As discussed on #11, this should solve the error on Digital Ocean:

```
unshare: cannot change root filesystem propagation: Invalid argument
```