### PR TITLE
NixOS fixes

### DIFF
--- a/install
+++ b/install
@@ -137,6 +137,8 @@ pushd "$working_directory"
   "$here/stage1" "$here" "$root_mount" "$root_type" "$grub_device" "$digitalocean"
 
   ## Minimize residual space usage
+  # /var/empty is immutable https://github.com/NixOS/nixpkgs/pull/18365
+  chattr -i ./host/var/empty
   rm -rf ./host
 popd
 

--- a/stage1
+++ b/stage1
@@ -16,7 +16,7 @@ log "Setting up chroot networking"
 cd host
 mkdir -p etc dev proc sys
 cp /etc/resolv.conf etc/external-resolv.conf
-for fn in dev proc sys; do mount --bind "/$fn" "$fn"; done
+for fn in dev dev/shm dev/pts proc sys; do mount --bind "/$fn" "$fn"; done
 
 ## Patch the ISO for local chroot
 log_start "Looking for NixOS init... "


### PR DESCRIPTION
These are needed to use nixos-minimal-16.09.680.4e14fd5-x86_64-linux.iso.