### PR TITLE
replaces no-extra-config with default-extra-config, closes #43

### DIFF
--- a/default-extra-config
+++ b/default-extra-config
@@ -1,0 +1,1 @@
+services.openssh.permitRootLogin = "yes";

--- a/install
+++ b/install
@@ -60,7 +60,7 @@ checksum=$minimal_checksum
 minimal_space=3
 graphical_space=5
 required_space=$minimal_space
-extra_config=$(readlink -f no-extra-config)
+extra_config=$(readlink -f default-extra-config)
 digitalocean=false
 
 while getopts ":g:r:t:Gdw:c:h" opt; do


### PR DESCRIPTION
The default-extra-config-file contains:

services.openssh.permitRootLogin = "yes";

in order to allow root login after reboot. This solves issue #43 . However maybe we should have this a real default without the indirection over the default-extra-config file?